### PR TITLE
Fix compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+zenmonitor

--- a/src/include/gui.h
+++ b/src/include/gui.h
@@ -1,6 +1,8 @@
 #ifndef __ZENMONITOR_GUI_H__
 #define __ZENMONITOR_GUI_H__
 
-int start_gui();
+#include "zenmonitor.h"
+
+int start_gui(SensorSource *ss);
 
 #endif /* __ZENMONITOR_GUI_H__ */


### PR DESCRIPTION
SensorSource not declared on gui header causing compilation error.