### PR TITLE
Fix signal handler arg type mismatch

### DIFF
--- a/src/zenmonitor-cli.c
+++ b/src/zenmonitor-cli.c
@@ -52,7 +52,7 @@ static SensorSource sensor_sources[] = {
     }
 };
 
-void flush_to_csv()
+void flush_to_csv(int signum)
 {
     FILE *csv;
     csv = fopen(file, "w");


### PR DESCRIPTION
Fixes build error:
src/zenmonitor-cli.c:206:24: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]

This is on top of PR #1 